### PR TITLE
Fix a minor bug in tinf_uncompress function.

### DIFF
--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -458,6 +458,7 @@ int tinf_uncompress(void *dest, unsigned int *destLen,
 
    d.destStart = (unsigned char *)dest;
    d.destRemaining = *destLen;
+   d.destSize = *destLen;
 
    res = tinf_uncompress_dyn(&d);
 


### PR DESCRIPTION
Without destSize being explicitly set, you get random failures
with TINF_DEST_OVERFLOW being returned (since destSize winds up
being initialized with a random value from the stack).
