### PR TITLE
Fix various crashes found by afl-fuzz

### DIFF
--- a/examples/tgunzip/tgunzip.c
+++ b/examples/tgunzip/tgunzip.c
@@ -117,7 +117,7 @@ int main(int argc, char *argv[])
         exit(1);
     }
 
-    d.dest = dest;
+    d.dest = d.destStart = dest;
     d.edest = dest + dlen;
     /* decompress byte by byte; can be any other length */
     d.destSize = 1;

--- a/examples/tgunzip/tgunzip.c
+++ b/examples/tgunzip/tgunzip.c
@@ -118,6 +118,7 @@ int main(int argc, char *argv[])
     }
 
     d.dest = dest;
+    d.edest = dest + dlen;
     /* decompress byte by byte; can be any other length */
     d.destSize = 1;
 

--- a/src/tinf.h
+++ b/src/tinf.h
@@ -74,8 +74,6 @@ typedef struct TINF_DATA {
     unsigned int destSize;
     /* Current pointer in buffer */
     unsigned char *dest;
-    /* Remaining bytes in buffer */
-    unsigned int destRemaining;
 
     /* Accumulating checksum */
     unsigned int checksum;

--- a/src/tinf.h
+++ b/src/tinf.h
@@ -74,6 +74,8 @@ typedef struct TINF_DATA {
     unsigned int destSize;
     /* Current pointer in buffer */
     unsigned char *dest;
+   /* end of destination buffer */
+    unsigned char *edest;
 
     /* Accumulating checksum */
     unsigned int checksum;

--- a/src/tinf.h
+++ b/src/tinf.h
@@ -94,12 +94,10 @@ typedef struct TINF_DATA {
    TINF_TREE dtree; /* dynamic distance tree */
 } TINF_DATA;
 
+
+void tinf_put(TINF_DATA *d, char c);
 #define TINF_PUT(d, c) \
-    { \
-        if(d->dest >= d->edest) return TINF_DATA_ERROR; \
-        *d->dest++ = c; \
-        if (d->dict_ring) { d->dict_ring[d->dict_idx++] = c; if (d->dict_idx == d->dict_size) d->dict_idx = 0; } \
-    }
+    tinf_put(d, c)
 
 unsigned char TINFCC uzlib_get_byte(TINF_DATA *d);
 

--- a/src/tinf.h
+++ b/src/tinf.h
@@ -96,6 +96,7 @@ typedef struct TINF_DATA {
 
 #define TINF_PUT(d, c) \
     { \
+        if(d->dest >= d->edest) return TINF_DATA_ERROR; \
         *d->dest++ = c; \
         if (d->dict_ring) { d->dict_ring[d->dict_idx++] = c; if (d->dict_idx == d->dict_size) d->dict_idx = 0; } \
     }

--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -272,12 +272,7 @@ static int tinf_decode_symbol(TINF_DATA *d, TINF_TREE *t)
 
    } while (cur >= 0);
 
-   sum += cur;
-   if (sum < 0 || sum >= TINF_ARRAY_SIZE(t->trans)) {
-      return TINF_DATA_ERROR;
-   }
-
-   return t->trans[sum];
+   return t->trans[sum + cur];
 }
 
 /* given a data stream, decode dynamic trees from it */

--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -545,6 +545,7 @@ next_blk:
 
     } while (--d->destSize);
 
+    if (d->eof) return TINF_DATA_ERROR;
     return TINF_OK;
 }
 
@@ -591,5 +592,6 @@ int uzlib_uncompress_chksum(TINF_DATA *d)
         }
     }
 
+    if (d->eof) res = TINF_DATA_ERROR;
     return res;
 }

--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -315,6 +315,7 @@ static int tinf_decode_trees(TINF_DATA *d, TINF_TREE *lt, TINF_TREE *dt)
    for (num = 0; num < hlimit; )
    {
       int sym = tinf_decode_symbol(d, lt);
+      if (sym < 0) return sym; // e.g., TINF_DATA_ERROR
       unsigned char fill_value = 0;
       int lbits, lbase = 3;
 

--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -592,6 +592,5 @@ int uzlib_uncompress_chksum(TINF_DATA *d)
         }
     }
 
-    if (d->eof) res = TINF_DATA_ERROR;
     return res;
 }

--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -416,6 +416,7 @@ static int tinf_inflate_block_data(TINF_DATA *d, TINF_TREE *lt, TINF_TREE *dt)
             d->lzOff = 0;
         }
     } else {
+        if(d->dest >= d->edest) return TINF_DATA_ERROR;
         d->dest[0] = d->dest[d->lzOff];
         d->dest++;
     }

--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -326,6 +326,7 @@ static int tinf_decode_trees(TINF_DATA *d, TINF_TREE *lt, TINF_TREE *dt)
       {
       case 16:
          /* copy previous code length 3-6 times (read 2 bits) */
+         if(num-1 >= sizeof(lengths)) return TINF_DATA_ERROR;
          fill_value = lengths[num - 1];
          lbits = 2;
          break;

--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -417,6 +417,10 @@ static int tinf_inflate_block_data(TINF_DATA *d, TINF_TREE *lt, TINF_TREE *dt)
         }
     } else {
         if(d->dest >= d->edest) return TINF_DATA_ERROR;
+        if(d->lzOff >= 0) return TINF_DATA_ERROR;
+        // d->dest + d->lzOff >= d->destStart but without undefined behavior due to constructing a pointer to before the d->dest
+        // subtract d->dest from both sides
+        if(d->lzOff < d->destStart - d->dest) return TINF_DATA_ERROR;
         d->dest[0] = d->dest[d->lzOff];
         d->dest++;
     }

--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -601,3 +601,9 @@ int uzlib_uncompress_chksum(TINF_DATA *d)
 
     return res;
 }
+
+void tinf_put(TINF_DATA *d, char c) {
+    if (d->dest >= d->edest) { d->eof = 1; return; }
+    *d->dest++ = c;
+    if (d->dict_ring) { d->dict_ring[d->dict_idx++] = c; if (d->dict_idx == d->dict_size) d->dict_idx = 0; }
+}


### PR DESCRIPTION
This set of changes fixes all the crashes afl-fuzz has found for me.

However, without a testsuite of inputs, it's tough to say whether it introduces any regressions.
I only tested on a single file, the GPL-3 license compressed by gnu gzip -9.
```
80d2ed30aa2c2f34cebc4cb05eac1095  GPL-3.gz
d32239bcb673463ab874e80d47fae504  GPL-3
```
and checked that after each commit, the decompression by tgunzip was the same as the original.

I particularly expect you will not be excited about the part that uses setjmp/longjmp.  Please let me know how you'd like me to rework that portion.  I tried making that code always return a fixed value (e.g., 0x00 or 0xff) but this led to decompressions going on "forever", where afl-fuzz defines "forever" as "1000ms".