### PR TITLE
Fix various crashes found by afl-fuzz (without longjmp)

### DIFF
--- a/examples/tgunzip/tgunzip.c
+++ b/examples/tgunzip/tgunzip.c
@@ -87,6 +87,8 @@ int main(int argc, char *argv[])
 
     fclose(fin);
 
+    if(len < 4) exit_error("impossibly small file");
+
     /* -- get decompressed length -- */
 
     dlen =            source[len - 1];

--- a/examples/tgunzip/tgunzip.c
+++ b/examples/tgunzip/tgunzip.c
@@ -117,7 +117,7 @@ int main(int argc, char *argv[])
 //    uzlib_uncompress_init(&d, malloc(32768), 32768);
     uzlib_uncompress_init(&d, NULL, 0);
 
-    d.dest = dest;
+    d.dest = d.destStart = dest;
     d.edest = dest + dlen;
     /* decompress byte by byte; can be any other length */
     d.destSize = 1;

--- a/examples/tgunzip/tgunzip.c
+++ b/examples/tgunzip/tgunzip.c
@@ -104,6 +104,7 @@ int main(int argc, char *argv[])
 
     TINF_DATA d;
     d.source = source;
+    d.esource = source + len;
 
     res = uzlib_gzip_parse_header(&d);
     if (res != TINF_OK) {
@@ -115,6 +116,7 @@ int main(int argc, char *argv[])
     uzlib_uncompress_init(&d, NULL, 0);
 
     d.dest = dest;
+    d.edest = dest + dlen;
     /* decompress byte by byte; can be any other length */
     d.destSize = 1;
 

--- a/src/tinf.h
+++ b/src/tinf.h
@@ -49,6 +49,8 @@ typedef struct {
 struct TINF_DATA;
 typedef struct TINF_DATA {
    const unsigned char *source;
+   /* end of source buffer */
+   const unsigned char *esource;
    /* If source above is NULL, this function will be used to read
       next byte from source stream */
    unsigned char (*readSource)(struct TINF_DATA *data);
@@ -62,6 +64,8 @@ typedef struct TINF_DATA {
     unsigned int destSize;
     /* Current pointer in buffer */
     unsigned char *dest;
+   /* end of destination buffer */
+    unsigned char *edest;
 
     /* Accumulating checksum */
     unsigned int checksum;

--- a/src/tinf.h
+++ b/src/tinf.h
@@ -70,6 +70,7 @@ typedef struct TINF_DATA {
     /* Accumulating checksum */
     unsigned int checksum;
     char checksum_type;
+    char eof;
 
     int btype;
     int bfinal;

--- a/src/tinf.h
+++ b/src/tinf.h
@@ -86,6 +86,7 @@ typedef struct TINF_DATA {
 
 #define TINF_PUT(d, c) \
     { \
+        if(d->dest >= d->edest) return TINF_DATA_ERROR; \
         *d->dest++ = c; \
         if (d->dict_ring) { d->dict_ring[d->dict_idx++] = c; if (d->dict_idx == d->dict_size) d->dict_idx = 0; } \
     }

--- a/src/tinf.h
+++ b/src/tinf.h
@@ -62,8 +62,6 @@ typedef struct TINF_DATA {
     unsigned int destSize;
     /* Current pointer in buffer */
     unsigned char *dest;
-    /* Remaining bytes in buffer */
-    unsigned int destRemaining;
 
     /* Accumulating checksum */
     unsigned int checksum;

--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -246,7 +246,7 @@ static int tinf_decode_symbol(TINF_DATA *d, TINF_TREE *t)
 
       cur = 2*cur + tinf_getbit(d);
 
-      ++len;
+      ++len; if(len == 16) return TINF_DATA_ERROR;
 
       sum += t->table[len];
       cur -= t->table[len];

--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -253,7 +253,9 @@ static int tinf_decode_symbol(TINF_DATA *d, TINF_TREE *t)
 
    } while (cur >= 0);
 
-   return t->trans[sum + cur];
+   sum += cur;
+   if(sum < 0 || sum >= 288) return TINF_DATA_ERROR;
+   return t->trans[sum];
 }
 
 /* given a data stream, decode dynamic trees from it */

--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -390,6 +390,7 @@ static int tinf_inflate_block_data(TINF_DATA *d, TINF_TREE *lt, TINF_TREE *dt)
             d->lzOff = 0;
         }
     } else {
+        if(d->dest >= d->edest) return TINF_DATA_ERROR;
         d->dest[0] = d->dest[d->lzOff];
         d->dest++;
     }

--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -182,7 +182,7 @@ uint32_t tinf_get_le_uint32(TINF_DATA *d)
     uint32_t val = 0;
     int i;
     for (i = 4; i--;) {
-        val = val >> 8 | uzlib_get_byte(d) << 24;
+        val = val >> 8 | ((uint32_t)uzlib_get_byte(d)) << 24;
     }
     return val;
 }

--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -362,9 +362,11 @@ static int tinf_inflate_block_data(TINF_DATA *d, TINF_TREE *lt, TINF_TREE *dt)
         /* substring from sliding dictionary */
         sym -= 257;
         /* possibly get more bits from length code */
+        if(sym < 0 || sym >= 30) return TINF_DATA_ERROR;
         d->curlen = tinf_read_bits(d, length_bits[sym], length_base[sym]);
 
         dist = tinf_decode_symbol(d, dt);
+        if(dist < 0 || dist >= 30) return TINF_DATA_ERROR;
         /* possibly get more bits from distance code */
         offs = tinf_read_bits(d, dist_bits[dist], dist_base[dist]);
         if (d->dict_ring) {

--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -257,7 +257,7 @@ static int tinf_decode_symbol(TINF_DATA *d, TINF_TREE *t)
 }
 
 /* given a data stream, decode dynamic trees from it */
-static void tinf_decode_trees(TINF_DATA *d, TINF_TREE *lt, TINF_TREE *dt)
+static int tinf_decode_trees(TINF_DATA *d, TINF_TREE *lt, TINF_TREE *dt)
 {
    unsigned char lengths[288+32];
    unsigned int hlit, hdist, hclen;
@@ -290,6 +290,7 @@ static void tinf_decode_trees(TINF_DATA *d, TINF_TREE *lt, TINF_TREE *dt)
    for (num = 0; num < hlit + hdist; )
    {
       int sym = tinf_decode_symbol(d, lt);
+      if(sym < 0) return sym; // i.e., TINF_DATA_ERROR
 
       switch (sym)
       {
@@ -327,6 +328,7 @@ static void tinf_decode_trees(TINF_DATA *d, TINF_TREE *lt, TINF_TREE *dt)
    /* build dynamic trees */
    tinf_build_tree(lt, lengths, hlit);
    tinf_build_tree(dt, lengths + hlit, hdist);
+   return TINF_OK;
 }
 
 /* ----------------------------- *

--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -476,7 +476,8 @@ next_blk:
                 tinf_build_fixed_trees(&d->ltree, &d->dtree);
             } else if (d->btype == 2) {
                 /* decode trees from stream */
-                tinf_decode_trees(d, &d->ltree, &d->dtree);
+                res = tinf_decode_trees(d, &d->ltree, &d->dtree);
+                if(res != TINF_OK) return res;
             }
         }
 

--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -398,6 +398,10 @@ static int tinf_inflate_block_data(TINF_DATA *d, TINF_TREE *lt, TINF_TREE *dt)
         }
     } else {
         if(d->dest >= d->edest) return TINF_DATA_ERROR;
+        if(d->lzOff >= 0) return TINF_DATA_ERROR;
+        // d->dest + d->lzOff >= d->destStart but without undefined behavior due to constructing a pointer to before the d->dest
+        // subtract d->dest from both sides
+        if(d->lzOff < d->destStart - d->dest) return TINF_DATA_ERROR;
         d->dest[0] = d->dest[d->lzOff];
         d->dest++;
     }


### PR DESCRIPTION
This set of changes fixes all the crashes afl-fuzz has found for me.

However, without a testsuite of inputs, it's tough to say whether it introduces any regressions.
I only tested on a single file, the GPL-3 license compressed by gnu gzip -9.
```
80d2ed30aa2c2f34cebc4cb05eac1095  GPL-3.gz
d32239bcb673463ab874e80d47fae504  GPL-3
```
and checked that after each commit, the decompression by tgunzip was the same as the original.

Unlike the original pull request (#10), this version avoids using setjmp/longjmp and has about half the impact on code size of the other version.

Code size with gcc 6.3 x86_64 -Os, before: 

```
   text	   data	    bss	    dec	    hex	filename
   2668	      0	      0	   2668	    a6c	tinflate.o
```
After:
```
   text	   data	    bss	    dec	    hex	filename
   2906	      0	      0	   2906	    b5a	tinflate.o
```
