### PR TITLE
Fix compiler warnings on 16-bit architecture

### DIFF
--- a/src/adler32.c
+++ b/src/adler32.c
@@ -74,5 +74,5 @@ uint32_t uzlib_adler32(const void *data, unsigned int length, uint32_t prev_sum 
       length -= k;
    }
 
-   return (s2 << 16) | s1;
+   return ((uint32_t)s2 << 16) | s1;
 }

--- a/src/crc32.c
+++ b/src/crc32.c
@@ -38,7 +38,7 @@
 
 #include "tinf.h"
 
-static const unsigned int tinf_crc32tab[16] = {
+static const uint32_t tinf_crc32tab[16] = {
    0x00000000, 0x1db71064, 0x3b6e20c8, 0x26d930ac, 0x76dc4190,
    0x6b6b51f4, 0x4db26158, 0x5005713c, 0xedb88320, 0xf00f9344,
    0xd6d6a3e8, 0xcb61b38c, 0x9b64c2b0, 0x86d3d2d4, 0xa00ae278,


### PR DESCRIPTION
On archtectures where unsigned int is only 16 bits the warning:
"unsigned conversion from 'long int' to 'unsigned int' changes
value from 'xxx' to 'yyy' [-Werror=overflow] and "left shift count
>= width of type [-Werror=shift-count-overflow]" where issued.