### PR TITLE
tinflate/crc32/adler32: add external destination buffer support

### DIFF
--- a/src/adler32.c
+++ b/src/adler32.c
@@ -55,18 +55,18 @@ uint32_t uzlib_adler32(const void *data, unsigned int length, uint32_t prev_sum 
 
       for (i = k / 16; i; --i, buf += 16)
       {
-         s1 += buf[0];  s2 += s1; s1 += buf[1];  s2 += s1;
-         s1 += buf[2];  s2 += s1; s1 += buf[3];  s2 += s1;
-         s1 += buf[4];  s2 += s1; s1 += buf[5];  s2 += s1;
-         s1 += buf[6];  s2 += s1; s1 += buf[7];  s2 += s1;
+         s1 += TINF_DEST_GETC(buf+0);  s2 += s1; s1 += TINF_DEST_GETC(buf + 1);  s2 += s1;
+         s1 += TINF_DEST_GETC(buf+2);  s2 += s1; s1 += TINF_DEST_GETC(buf + 3);  s2 += s1;
+         s1 += TINF_DEST_GETC(buf+4);  s2 += s1; s1 += TINF_DEST_GETC(buf + 5);  s2 += s1;
+         s1 += TINF_DEST_GETC(buf+6);  s2 += s1; s1 += TINF_DEST_GETC(buf + 7);  s2 += s1;
 
-         s1 += buf[8];  s2 += s1; s1 += buf[9];  s2 += s1;
-         s1 += buf[10]; s2 += s1; s1 += buf[11]; s2 += s1;
-         s1 += buf[12]; s2 += s1; s1 += buf[13]; s2 += s1;
-         s1 += buf[14]; s2 += s1; s1 += buf[15]; s2 += s1;
+         s1 += TINF_DEST_GETC(buf+8);  s2 += s1; s1 += TINF_DEST_GETC(buf + 9);  s2 += s1;
+         s1 += TINF_DEST_GETC(buf+10); s2 += s1; s1 += TINF_DEST_GETC(buf + 11); s2 += s1;
+         s1 += TINF_DEST_GETC(buf+12); s2 += s1; s1 += TINF_DEST_GETC(buf + 13); s2 += s1;
+         s1 += TINF_DEST_GETC(buf+14); s2 += s1; s1 += TINF_DEST_GETC(buf + 15); s2 += s1;
       }
 
-      for (i = k % 16; i; --i) { s1 += *buf++; s2 += s1; }
+      for (i = k % 16; i; --i) { s1 += TINF_DEST_GETC(buf++); s2 += s1; }
 
       s1 %= A32_BASE;
       s2 %= A32_BASE;

--- a/src/crc32.c
+++ b/src/crc32.c
@@ -53,7 +53,7 @@ uint32_t uzlib_crc32(const void *data, unsigned int length, uint32_t crc)
 
    for (i = 0; i < length; ++i)
    {
-      crc ^= buf[i];
+      crc ^= TINF_DEST_GETC(buf+i);
       crc = tinf_crc32tab[crc & 0x0f] ^ (crc >> 4);
       crc = tinf_crc32tab[crc & 0x0f] ^ (crc >> 4);
    }

--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -35,6 +35,7 @@
 #include <assert.h>
 #include <string.h>
 #include "tinf.h"
+#include "uzlib_conf.h"
 
 #define UZLIB_DUMP_ARRAY(heading, arr, size) \
     { \
@@ -490,7 +491,7 @@ static int tinf_inflate_block_data(TINF_DATA *d, TINF_TREE *lt, TINF_TREE *dt)
         d->curlen -= to_copy;
         return TINF_OK;
         #else
-        d->dest[0] = d->dest[d->lzOff];
+        TINF_DEST_PUTC(TINF_DEST_GETC(d->dest + d->lzOff));
         d->dest++;
         #endif
     }

--- a/src/uzlib.h
+++ b/src/uzlib.h
@@ -123,9 +123,19 @@ struct uzlib_uncomp {
 
 #include "tinf_compat.h"
 
+
+#ifndef TINF_DEST_PUTC
+#define TINF_DEST_PUTC(c) do { *d->dest = c; } while(0)
+#endif
+
+#ifndef TINF_DEST_GETC
+#define TINF_DEST_GETC(addr) ({ unsigned char ret = *(addr); ret; })
+#endif
+
 #define TINF_PUT(d, c) \
     { \
-        *d->dest++ = c; \
+        TINF_DEST_PUTC(c); \
+        d->dest++; \
         if (d->dict_ring) { d->dict_ring[d->dict_idx++] = c; if (d->dict_idx == d->dict_size) d->dict_idx = 0; } \
     }
 

--- a/src/uzlib_conf.h
+++ b/src/uzlib_conf.h
@@ -29,4 +29,12 @@
 #define UZLIB_CONF_USE_MEMCPY 0
 #endif
 
+/* Custom TINF_DEST_PUTC / TINF_DEST_GETC implementation */
+
+#define TINF_DEST_PUTC uzlib_dest_putc
+extern void uzlib_dest_putc(uint8_t c);
+
+#define TINF_DEST_GETC uzlib_dest_getc
+extern uint8_t uzlib_dest_getc(const uint8_t *addr);
+
 #endif /* UZLIB_CONF_H_INCLUDED */


### PR DESCRIPTION
Following #32 I prepared following - rather small - code changes.

Goal:
Allow an external buffer (like MCU flash memory, an SDcard, SPI flash, ...) to be used as destination for decompression,
while still just requiring minimal changes to the existing code.

Approach:
Two new macros are introduced:
`TINF_DEST_PUTC(c)` and `TINF_DEST_GETC(addr)`
When not defined, they will just revert to the exact same code as currently used in uzlib.
When override, they allow to remap the read(`getc`) + write (`putc`) actions to be override however is appropriate for the project.

I just looked at the newly pushed memcpy approach as well ( https://github.com/pfalcon/uzlib/commit/2aeab6c76bd385f72998780296d9d928c893a732 ), but it does not seem to solve the issue quite in the same way. I believe both solutions can exist next to each other.

My target use case is a small MCU with only small amount of RAM, in which case I do not want to use a dictionary, and preferably don't have to override memcpy, since performance is not important, but rather a small memory footprint is (RAM- and ROM-wise)

Let me know what you think, and any adjustments you would require!

Cheers, and thanks again for the project!