### PR TITLE
C linkage for defl_static.h + uzlib_conf.h in C++

### DIFF
--- a/src/uzlib.h
+++ b/src/uzlib.h
@@ -39,6 +39,10 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "defl_static.h"
 
 #include "uzlib_conf.h"
@@ -53,10 +57,6 @@
  #else
   #define TINFCC
  #endif
-#endif
-
-#ifdef __cplusplus
-extern "C" {
 #endif
 
 /* ok status, more data produced */


### PR DESCRIPTION
Needed for compressing in zlib format from C++ source code. Otherwise uzlib.h will need an additional extern "C" { } frame around it.

I have only tried compilation in my own project so far, not with the examples, but I think this should be fairly safe. I will build the examples later on and report back as well.