### PR TITLE
Fix out-of-bounds reads due to missing error handling

### DIFF
--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -294,11 +294,9 @@ static int tinf_decode_symbol(TINF_DATA *d, TINF_TREE *t)
    } while (cur >= 0);
 
    sum += cur;
-   #if UZLIB_CONF_PARANOID_CHECKS
    if (sum < 0 || sum >= TINF_ARRAY_SIZE(t->trans)) {
       return TINF_DATA_ERROR;
    }
-   #endif
 
    return t->trans[sum];
 }
@@ -410,6 +408,7 @@ static int tinf_inflate_block_data(TINF_DATA *d, TINF_TREE *lt, TINF_TREE *dt)
         unsigned int offs;
         int dist;
         int sym = tinf_decode_symbol(d, lt);
+        if (sym < 0) return sym;
         //printf("huff sym: %02x\n", sym);
 
         if (d->eof) {
@@ -437,6 +436,7 @@ static int tinf_inflate_block_data(TINF_DATA *d, TINF_TREE *lt, TINF_TREE *dt)
         d->curlen = tinf_read_bits(d, length_bits[sym], length_base[sym]);
 
         dist = tinf_decode_symbol(d, dt);
+        if (dist < 0) return dist;
         if (dist >= 30) {
             return TINF_DATA_ERROR;
         }


### PR DESCRIPTION
Using `libfuzzer` with the following code (inspired from `examples/tgunzip.c`, and `UZLIB_CONF_PARANOID_CHECKS=1`)  led to a crash:

```c
#include "uzlib.h"
#include <stddef.h>
#include <stdint.h>

#define OUT_SIZE 8192

int uncompress(const uint8_t * data, size_t length) {
    struct uzlib_uncomp d;
    uint32_t dlen;
    int32_t res;
    uint8_t * dest = (uint8_t *)malloc(OUT_SIZE);
    if (dest == NULL) return -1;

    uzlib_uncompress_init(&d, NULL, 0);

    d.source = data;
    d.source_limit = &data[length - 4];
    d.source_read_cb = NULL;

    res = uzlib_zlib_parse_header(&d);
    if (res != TINF_OK) {
        return -1;
    }

    d.dest_start = d.dest = dest;
    d.dest_limit = &dest[OUT_SIZE];

    if (uzlib_uncompress(&d) != TINF_OK) {
        return -1;
    }
    return 0;
}

int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
    if (Size > 4) {
        uncompress(Data, Size);
    }
    return 0;
}
```
(compiled with `clang` and `-fsanitize=fuzzer,address -g -O3 -ggdb2`)

It can be reproduced with this input (although there are several possibilities):
`\x08\xd7\xba\xf9\x08\x01(\x01\x00\x06\xd7\xba\xf9\x08&\x01ggggggggggggggggggggggggg\x08\xd7\xbaggggg\x04\x00\xb8\x07gggggggggggggggggg6666666666666\x00666666666666666666666`

The reason for this is that although `tinf_decode_symbol()` can return an error [here](https://github.com/pfalcon/uzlib/blob/master/src/tinflate.c#L299), it is not propagated to the caller [here](https://github.com/pfalcon/uzlib/blob/master/src/tinflate.c#L412) and [here](https://github.com/pfalcon/uzlib/blob/master/src/tinflate.c#L439) and ends up being used as an index into a table, which is incorrect since `TINF_DATA_ERROR` is negative.

This PR fixes this problem and removes the `#if UZLIB_CONF_PARANOID_CHECKS` in `tinf_decode_symbol` since this shows a case where it leads to a crash.