### PR TITLE
tinflate.c: Add cast to fix signedness check

### DIFF
--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -465,7 +465,7 @@ static int tinf_inflate_block_data(TINF_DATA *d, TINF_TREE *lt, TINF_TREE *dt)
             }
         } else {
             /* catch trying to point before the start of dest buffer */
-            if (offs > d->dest - d->destStart) {
+            if (offs > (unsigned)(d->dest - d->destStart)) {
                 return TINF_DATA_ERROR;
             }
             d->lzOff = -offs;


### PR DESCRIPTION
A simple fix, but allows our code to compile with -Wextra and -Werror.