### PR TITLE
Add support for zephyr RTOS

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -27,7 +27,7 @@ $(target): $(objects)
 	ranlib $@
 
 %.o : %.c
-	$(CC) $(CFLAGS) -o $@ -c $<
+	$(CC) $(CFLAGS) -o $@ -I. -c $<
 
 %.o : %.nas
 	nasm -o $@ -f elf -D_ELF_ -O3 -Inasm/ $<

--- a/src/uzlib.h
+++ b/src/uzlib.h
@@ -43,7 +43,7 @@
 extern "C" {
 #endif
 
-#include "uzlib_conf.h"
+#include <uzlib_conf.h>
 #if UZLIB_CONF_DEBUG_LOG
 #include <stdio.h>
 #endif

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+if(CONFIG_UZLIB)
+zephyr_include_directories(
+  .
+  ../src
+)
+
+zephyr_library_sources(
+  ../src/crc32.c
+)
+zephyr_library_sources_ifdef(CONFIG_UZLIB_DECOMPRESS
+  ../src/adler32.c
+  ../src/tinflate.c
+  ../src/tinfgzip.c
+  ../src/tinfzlib.c
+)
+zephyr_library_sources_ifdef(CONFIG_UZLIB_COMPRESS
+  ../src/genlz77.c
+  ../src/defl_static.c
+)
+endif()

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -1,0 +1,41 @@
+# uzlib module configuration options
+
+config UZLIB
+	bool "Enable uzlib library"
+
+if UZLIB
+	
+config UZLIB_COMPRESS
+	bool "Enable compression"
+	default y
+	
+config UZLIB_DECOMPRESS
+	bool "Enable decompression"
+	default n
+	
+config UZLIB_DEBUG_LOG
+	int "Debug log level"
+	default 0
+	help
+	  	Debug logging level 0, 1, 2, etc.
+	
+config UZLIB_PARANOID_CHECKS
+	bool "Enable paranoid checks"
+	default n
+	help
+		Perform extra checks on the input stream, even if they aren't proven
+		to be strictly required (== lack of them wasn't proven to lead to
+		crashes).
+	
+config UZLIB_USE_MEMCPY
+	bool "Enable memcpy"
+	default n
+	help
+	  	Use memcpy() for copying data out of LZ window or uncompressed blocks,
+		instead of doing this byte by byte. For well-compressed data, this
+		may noticeably increase decompression speed. But for less compressed,
+		it can actually deteriorate it (due to the fact that many memcpy()
+		implementations are optimized for large blocks of data, and have
+		too much overhead for short strings of just a few bytes).
+	
+endif # UZLIB

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,3 @@
+build:
+  cmake: zephyr
+  kconfig: zephyr/Kconfig

--- a/zephyr/uzlib_conf.h
+++ b/zephyr/uzlib_conf.h
@@ -1,0 +1,27 @@
+/*
+ * uzlib  -  tiny deflate/inflate library (deflate, gzip, zlib)
+ *
+ * Copyright (c) 2014-2018 by Paul Sokolovsky
+ */
+#ifndef UZLIB_CONF_H_INCLUDED
+#define UZLIB_CONF_H_INCLUDED
+
+#include <zephyr.h>
+
+/* Debug logging level 0, 1, 2, etc. */
+#define UZLIB_CONF_DEBUG_LOG CONFIG_UZLIB_DEBUG_LOG
+
+/* Perform extra checks on the input stream, even if they aren't proven
+   to be strictly required (== lack of them wasn't proven to lead to
+   crashes). */
+#define UZLIB_CONF_PARANOID_CHECKS IS_ENABLED(CONFIG_UZLIB_PARANOID_CHECKS)
+
+/* Use memcpy() for copying data out of LZ window or uncompressed blocks,
+   instead of doing this byte by byte. For well-compressed data, this
+   may noticeably increase decompression speed. But for less compressed,
+   it can actually deteriorate it (due to the fact that many memcpy()
+   implementations are optimized for large blocks of data, and have
+   too much overhead for short strings of just a few bytes). */
+#define UZLIB_CONF_USE_MEMCPY IS_ENABLED(CONFIG_UZLIB_USE_MEMCPY)
+
+#endif /* UZLIB_CONF_H_INCLUDED */


### PR DESCRIPTION
Zephyr does not provide compression libraries such as gzip or zlib. Uzlib is a good candidate as a small footprint library. This adds support to integrate and build uzlib as  zephyr module.

Changes:
* Use <> type include instead of quote includes for uzlib_conf.h to be able to override conf for zephyr.
* Added zephyr directory for module build variant
* Ported uzlib configuration to Kconfig

Features:
* Module can be configured to build for compression or/and decompression
* Uzlib configuration through Kconfig